### PR TITLE
Adding parsing for the alias endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,6 @@ tags
 [._]*.un~
 
 # End of https://www.gitignore.io/api/go,vim,linux,macos
+
+# generated binary 
+opnsense-go

--- a/README.md
+++ b/README.md
@@ -8,3 +8,4 @@ Currently the parts of the API thats needed for other projects are implemented:
 * BGP Neighbors
 * Backup
 * Package management
+* Alias

--- a/main.go
+++ b/main.go
@@ -8,10 +8,7 @@ import (
 )
 
 func main() {
-	c, err := opnsense.NewClient("http://192.168.45.128",
-		"98JfUoQ9QI8YUsUZ6h1eGG9PHaEFnBELf5ANlV/lTv5bWchyPOyZVV2a70rdDV0PvThBwzYYSLR0c/J1",
-		"MlMrlTkepR+CNuqpZ/dpBYcloiWogKPtgixM988MuPK7hYUtMFUsI1AQoHhfuqhEdEDPK0BXW8SN7V/0",
-		true)
+	c, err := opnsense.NewClient("http://localhost:8080", "", "", true)
 
 	if err != nil {
 		log.Fatal(err)

--- a/main.go
+++ b/main.go
@@ -1,48 +1,129 @@
 package main
 
 import (
-	"log"
-
+	"fmt"
 	"github.com/kradalby/opnsense-go/opnsense"
-	"github.com/satori/go.uuid"
+	//"github.com/satori/go.uuid"
+	"log"
 )
 
 func main() {
-	// c, err := opnsense.NewClient("http://localhost:8080", "", "", true)
+	c, err := opnsense.NewClient("http://192.168.45.128",
+		"98JfUoQ9QI8YUsUZ6h1eGG9PHaEFnBELf5ANlV/lTv5bWchyPOyZVV2a70rdDV0PvThBwzYYSLR0c/J1",
+		"MlMrlTkepR+CNuqpZ/dpBYcloiWogKPtgixM988MuPK7hYUtMFUsI1AQoHhfuqhEdEDPK0BXW8SN7V/0",
+		true)
+
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	// resp, err := c.WireGuardGetSettings()
-	// log.Printf("Error: %#v", err)
-	// log.Printf("%#v,", resp)
-	// err = c.WireGuardEnableService()
-	// log.Printf("Error: %#v", err)
-	// resp, err = c.WireGuardGetSettings()
-	// log.Printf("Error: %#v", err)
-	// log.Printf("%#v,", resp)
-	// err = c.WireGuardDisableService()
-	// log.Printf("Error: %#v", err)
-	// resp, err = c.WireGuardGetSettings()
-	// log.Printf("%#v,", resp)
-	// log.Printf("Error: %#v", err)
-	// err = c.WireGuardEnableService()
-	// log.Printf("Error: %#v", err)
+	// TEST ALIAS
+	/*var default_name = "LUUL"
+	var default_desc = default_name
 
-	// b, err := c.Backup()
-	// if err != nil {
-	// 	log.Printf("Error: %#v", err)
-	// }
-	// log.Printf("%s", b)
+	// get all alias
+	var all_uiid, _ = c.AliasGetUUIDs()
+	if len(all_uiid) > 0 {
+		fmt.Println(all_uiid[0])
 
-	// clients, err := c.BgpNeighborList()
-	// if err != nil {
-	// 	log.Printf("Error: %#v", err)
-	// }
+		// get info for the first alias in the list
+		var u = all_uiid[0]
+		var resp_get, _ = c.AliasGet(*u)
+		fmt.Println("name :", resp_get.Name)
+		fmt.Println("uiid :", resp_get.UUID)
+		fmt.Println("description :", resp_get.Description)
+		fmt.Println("enabled :", resp_get.Enabled)
+		fmt.Println("type :", resp_get.Type)
+		fmt.Println("content :", resp_get.Content)
+		fmt.Println("proto :", resp_get.Proto)
 
-	u, _ := uuid.FromString("9cc6398c-26ca-4cae-8ff0-8bb97114bdd0")
-	resp, err := c.WireGuardServerGet(u)
-	log.Println(err)
-	log.Printf("%#v", resp)
+		default_name = resp_get.Name
+		default_desc = resp_get.Description
 
+		// delete this alias
+		var resp_del, _ = c.AliasDelete(*u)
+		fmt.Println("DEL :", resp_del)
+	}
+
+	// create or recreate the same alias
+	var add_set opnsense.AliasSet
+	add_set.Description = default_desc + " NEW "
+	add_set.Name = default_name
+	add_set.Enabled = "1"
+	add_set.Type = "host"
+	add_set.Proto = ""
+	add_set.Updatefreq = ""
+	add_set.Content = ""
+	add_set.Counters = ""
+	var resp_add, err_add = c.AliasAdd(add_set)
+	if err_add != nil {
+		log.Println(err_add)
+	}
+
+	fmt.Println("new uiid added : ", resp_add)
+
+	var resp_get_after_add, _ = c.AliasGet(*resp_add)
+
+	// update the created alias
+	var update_set opnsense.AliasSet
+	update_set.Description = resp_get_after_add.Description + " UPDATE "
+	update_set.Name = resp_get_after_add.Name
+	update_set.Enabled = "1"
+	update_set.Type = "host"
+	update_set.Proto = ""
+	update_set.Updatefreq = ""
+	update_set.Content = "178.132\nLLLLLL"
+	update_set.Counters = ""
+	var _, err_update = c.AliasUpdate(*resp_add, update_set)
+
+	if err_update != nil {
+		log.Println(err_update)
+	}
+
+	// TEST ALIAS PUSH
+	/*alias_name := "TEST"
+	var add_set opnsense.AliasPushSet
+	add_set.Address = "10.0.0.11"
+	var res_add, err_add = c.AliasPushAdd(alias_name, add_set)
+
+	if err_add != nil {
+		log.Println(err_add)
+		fmt.Println(res_add)
+		return
+	}
+
+	var add_del opnsense.AliasPushSet
+	add_del.Address = "10.0.0.10"
+	var res_del, err_del = c.AliasPushDel(alias_name, add_del)
+
+	if err_add != nil {
+		log.Println(err_del)
+		fmt.Println(res_del)
+	}*/
+
+	/*uuid, err_uuid := uuid.FromString("fd89c801-adb3-42f5-94d7-293655ac205c")
+	if err_uuid != nil {
+		fmt.Printf("Something went wrong: %s", err_uuid)
+		return
+	}
+	alias, err_get := c.AliasGet(uuid)
+	if err_get != nil {
+		fmt.Printf("Something went wrong: %s", err_get)
+		return
+	}
+
+	alias.Content = append(alias.Content, "10.0.0.1")
+
+	_, err_update := c.AliasUpdate(uuid, *alias)
+
+	if err_update != nil {
+		log.Println(err_update)
+	}*/
+
+	list, err_list := c.AliasGetList()
+	if err_list != nil {
+		log.Println(err_list)
+	}
+
+	fmt.Printf("%v", *list)
 }

--- a/opnsense/alias.go
+++ b/opnsense/alias.go
@@ -1,0 +1,280 @@
+package opnsense
+
+import (
+	"fmt"
+	"log"
+	"path"
+	"strings"
+
+	uuid "github.com/satori/go.uuid"
+)
+
+type AliasBase struct {
+	Enabled     string `json:"enabled"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Updatefreq  string `json:"updatefreq"`
+	Counters    string `json:"counters"`
+}
+
+type AliasSet struct {
+	AliasBase
+	Type    string `json:"type"`
+	Proto   string `json:"proto"`
+	Content string `json:"content"`
+}
+
+type AliasGet struct {
+	Type    map[string]AliasNestedValue `json:"type"`
+	Proto   map[string]AliasNestedValue `json:"proto"`
+	Content map[string]AliasNestedValue `json:"content"`
+	AliasBase
+}
+
+type AliasNestedValue struct {
+	Value    string `json:"value"`
+	Selected int    `json:"selected"`
+}
+
+type AliasList struct {
+	Rows     []AliasListItem `json:"rows"`
+	RowCount int             `json:"rowCount"`
+	Total    int             `json:"total"`
+	Current  int             `json:"current"`
+}
+
+type AliasListItem struct {
+	UUID        string `json:"uuid"`
+	Enabled     string `json:"enabled"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Type        string `json:"type"`
+	Content     string `json:"content"`
+}
+
+type AliasFormat struct {
+	UUID        *uuid.UUID
+	Enabled     bool
+	Name        string
+	Description string
+	Updatefreq  string
+	Counters    string
+	Type        string
+	Proto       string
+	Content     []string
+}
+
+type AliasReconfigureResponse struct {
+	Status string `json:"status"`
+}
+
+func (c *Client) AliasGet(uuid uuid.UUID) (*AliasFormat, error) {
+	type Response struct {
+		Alias AliasGet `json:"alias"`
+	}
+	var raw_response Response
+
+	err := c.GetAndUnmarshal(path.Join("firewall/alias/getItem", uuid.String()), &raw_response)
+	if err != nil {
+		return nil, err
+	}
+
+	var response AliasFormat
+	response.UUID = &uuid
+	response.Enabled = raw_response.Alias.Enabled == "1"
+	response.Name = raw_response.Alias.Name
+	response.Description = raw_response.Alias.Description
+	response.Updatefreq = raw_response.Alias.Updatefreq
+	response.Counters = raw_response.Alias.Counters
+
+	for k, v := range raw_response.Alias.Type {
+		if v.Selected == 1 && k != "" {
+			response.Type = k
+			break
+		}
+	}
+
+	for k, v := range raw_response.Alias.Content {
+		if v.Selected == 1 && k != "" {
+			response.Content = append(response.Content, v.Value)
+		}
+	}
+
+	return &response, err
+}
+
+func (c *Client) AliasGetList() (*AliasList, error) {
+	var response AliasList
+
+	err := c.GetAndUnmarshal("firewall/alias/searchItem", &response)
+	if err != nil {
+		return nil, err
+	}
+
+	return &response, err
+}
+
+func (c *Client) AliasUpdate(uuid uuid.UUID, conf AliasFormat) (*GenericResponse, error) {
+	type Request struct {
+		Alias AliasSet `json:"alias"`
+	}
+
+	var request Request
+	request.Alias = AliasFormatToSet(conf)
+
+	var response GenericResponse
+	err := c.PostAndMarshal(path.Join("firewall/alias/setItem", uuid.String()), request, &response)
+	if err != nil {
+		return nil, err
+	}
+
+	if response.Result != "saved" {
+		err := fmt.Errorf("Failed to save, response from server: %#v", response)
+		log.Printf("[ERROR] %#v\n", err)
+		return nil, err
+	}
+
+	return &response, nil
+}
+
+func (c *Client) AliasAdd(conf AliasFormat) (*uuid.UUID, error) {
+	type Request struct {
+		Alias AliasSet `json:"alias"`
+	}
+	var request Request
+	request.Alias = AliasFormatToSet(conf)
+
+	var response GenericResponse
+	err := c.PostAndMarshal("firewall/alias/addItem", request, &response)
+	if err != nil {
+		return nil, err
+	}
+
+	if response.Result != "saved" {
+		err := fmt.Errorf("Failed to save, response from server: %#v", response)
+		log.Printf("[ERROR] %#v\n", err)
+		return nil, err
+	}
+
+	return response.UUID, nil
+}
+
+func AliasFormatToSet(conf AliasFormat) AliasSet {
+	var set AliasSet
+
+	if conf.Enabled {
+		set.Enabled = "1"
+	} else {
+		set.Enabled = "0"
+	}
+	set.Name = conf.Name
+	set.Description = conf.Description
+	set.Updatefreq = conf.Updatefreq
+	set.Counters = conf.Counters
+	set.Type = conf.Type
+	set.Proto = conf.Proto
+	set.Content = strings.Join(conf.Content, "\n")
+
+	return set
+}
+
+func (c *Client) AliasDelete(uuid uuid.UUID) (*GenericResponse, error) {
+	var response GenericResponse
+	err := c.PostAndMarshal(path.Join("firewall/alias/delItem", uuid.String()), nil, &response)
+	if err != nil {
+		return nil, err
+	}
+
+	if response.Result != "deleted" {
+		err := fmt.Errorf("Failed to delete, response from server: %#v", response)
+		log.Printf("[ERROR] %#v\n", err)
+		return nil, err
+	}
+
+	return &response, nil
+}
+
+func (c *Client) AliasReconfigure() (*AliasReconfigureResponse, error) {
+	var response AliasReconfigureResponse
+	request := map[string]interface{}{}
+
+	err := c.PostAndMarshal("firewall/alias/reconfigure", request, &response)
+	if err != nil {
+		return nil, err
+	}
+
+	if response.Status != "ok" {
+		err := fmt.Errorf("Failed to reconfigure, response from server: %#v", response)
+		log.Printf("[ERROR] %#v\n", err)
+		return nil, err
+	}
+
+	return &response, nil
+}
+
+//// ALIAS UILS SECTION ////
+type AliasUtilsGet struct {
+	Name     string           `json:"name"`
+	Total    int              `json:"total"`
+	RowCount int              `json:"rowCount"`
+	Current  int              `json:"current"`
+	Rows     []AliasUtilsInfo `json:"rows"`
+}
+
+type AliasUtilsInfo struct {
+	Address string `json:"ip"`
+}
+
+type AliasUtilsSet struct {
+	Address string `json:"address"`
+}
+
+type AliasUtilsResponse struct {
+	Status string `json:"status"`
+}
+
+func (c *Client) AliasUtilsGet(name string) (*AliasUtilsGet, error) {
+	var response AliasUtilsGet
+
+	err := c.GetAndUnmarshal(path.Join("firewall/alias_util/list", name), &response)
+
+	if err != nil {
+		return nil, err
+	}
+
+	response.Name = name
+
+	return &response, nil
+}
+
+func (c *Client) AliasUtilsAdd(name string, request AliasUtilsSet) (*AliasUtilsResponse, error) {
+	var response AliasUtilsResponse
+	err := c.PostAndMarshal(path.Join("firewall/alias_util/add", name), request, &response)
+	if err != nil {
+		return nil, err
+	}
+
+	if response.Status != "done" {
+		err := fmt.Errorf("Failed to save, response from server: %#v", response)
+		log.Printf("[ERROR] %#v\n", err)
+		return nil, err
+	}
+
+	return &response, nil
+}
+
+func (c *Client) AliasUtilsDel(name string, request AliasUtilsSet) (*AliasUtilsResponse, error) {
+	var response AliasUtilsResponse
+	err := c.PostAndMarshal(path.Join("firewall/alias_util/delete", name), request, &response)
+	if err != nil {
+		return nil, err
+	}
+
+	if response.Status != "done" {
+		err := fmt.Errorf("Failed to save, response from server: %#v", response)
+		log.Printf("[ERROR] %#v\n", err)
+		return nil, err
+	}
+
+	return &response, nil
+}

--- a/opnsense/client.go
+++ b/opnsense/client.go
@@ -85,6 +85,12 @@ func (c *Client) GetAndUnmarshal(api string, responseData interface{}) error {
 		return err
 	}
 
+	// add possible internal error from the OPNSense API
+	if resp.StatusCode == 500 {
+		log.Printf("[ERROR] Internal Error status code received: %#v\n", string(body))
+		return fmt.Errorf("Internal Error status code received")
+	}
+
 	// The OPNsense API does not return 404 when you fetch something that does
 	// not exist, but returns an empty list instead. Check for the empty list
 	// and return a 404 error instead so implmenters could handle that error


### PR DESCRIPTION
With this commit the library can now be used to manage alias with the standard alias endpoint and the alias_util endpoint
With the alias endpoint we can
	- retrieved an alias by UUID
	- create un alias
	- delete un alias by UUID
	- update an alias by UUID
	- List all alias
With the alias_util endpoint we can
	- retrieved all address assigned to an alias of type host or network
	- add an address to an alias of type host or network
	- remove an address to an alias of type host or network